### PR TITLE
fix -Wunreachable-code-loop-increment

### DIFF
--- a/gpu_tonemapper/glengine.cpp
+++ b/gpu_tonemapper/glengine.cpp
@@ -315,36 +315,30 @@ void checkGlError(const char *file, int line)
 //-----------------------------------------------------------------------------
 {
   for (GLint error = glGetError(); error; error = glGetError()) {
-    char *pError;
+    const char *pError = "<unknown error>";
     switch (error) {
       case GL_NO_ERROR:
-        pError = (char *)"GL_NO_ERROR";
+        pError = "GL_NO_ERROR";
         break;
       case GL_INVALID_ENUM:
-        pError = (char *)"GL_INVALID_ENUM";
+        pError = "GL_INVALID_ENUM";
         break;
       case GL_INVALID_VALUE:
-        pError = (char *)"GL_INVALID_VALUE";
+        pError = "GL_INVALID_VALUE";
         break;
       case GL_INVALID_OPERATION:
-        pError = (char *)"GL_INVALID_OPERATION";
+        pError = "GL_INVALID_OPERATION";
         break;
       case GL_OUT_OF_MEMORY:
-        pError = (char *)"GL_OUT_OF_MEMORY";
+        pError = "GL_OUT_OF_MEMORY";
         break;
       case GL_INVALID_FRAMEBUFFER_OPERATION:
-        pError = (char *)"GL_INVALID_FRAMEBUFFER_OPERATION";
+        pError = "GL_INVALID_FRAMEBUFFER_OPERATION";
         break;
-
-      default:
-        ALOGE("glError (0x%x) %s:%d\n", error, file, line);
-        return;
     }
 
     ALOGE("glError (%s) %s:%d\n", pError, file, line);
-    return;
   }
-  return;
 }
 
 //-----------------------------------------------------------------------------
@@ -357,59 +351,54 @@ void checkEglError(const char *file, int line)
       break;
     }
 
-    char *pError;
+    const char *pError = "<unknown error>";
     switch (error) {
       case EGL_SUCCESS:
-        pError = (char *)"EGL_SUCCESS";
+        pError = "EGL_SUCCESS";
         break;
       case EGL_NOT_INITIALIZED:
-        pError = (char *)"EGL_NOT_INITIALIZED";
+        pError = "EGL_NOT_INITIALIZED";
         break;
       case EGL_BAD_ACCESS:
-        pError = (char *)"EGL_BAD_ACCESS";
+        pError = "EGL_BAD_ACCESS";
         break;
       case EGL_BAD_ALLOC:
-        pError = (char *)"EGL_BAD_ALLOC";
+        pError = "EGL_BAD_ALLOC";
         break;
       case EGL_BAD_ATTRIBUTE:
-        pError = (char *)"EGL_BAD_ATTRIBUTE";
+        pError = "EGL_BAD_ATTRIBUTE";
         break;
       case EGL_BAD_CONTEXT:
-        pError = (char *)"EGL_BAD_CONTEXT";
+        pError = "EGL_BAD_CONTEXT";
         break;
       case EGL_BAD_CONFIG:
-        pError = (char *)"EGL_BAD_CONFIG";
+        pError = "EGL_BAD_CONFIG";
         break;
       case EGL_BAD_CURRENT_SURFACE:
-        pError = (char *)"EGL_BAD_CURRENT_SURFACE";
+        pError = "EGL_BAD_CURRENT_SURFACE";
         break;
       case EGL_BAD_DISPLAY:
-        pError = (char *)"EGL_BAD_DISPLAY";
+        pError = "EGL_BAD_DISPLAY";
         break;
       case EGL_BAD_SURFACE:
-        pError = (char *)"EGL_BAD_SURFACE";
+        pError = "EGL_BAD_SURFACE";
         break;
       case EGL_BAD_MATCH:
-        pError = (char *)"EGL_BAD_MATCH";
+        pError = "EGL_BAD_MATCH";
         break;
       case EGL_BAD_PARAMETER:
-        pError = (char *)"EGL_BAD_PARAMETER";
+        pError = "EGL_BAD_PARAMETER";
         break;
       case EGL_BAD_NATIVE_PIXMAP:
-        pError = (char *)"EGL_BAD_NATIVE_PIXMAP";
+        pError = "EGL_BAD_NATIVE_PIXMAP";
         break;
       case EGL_BAD_NATIVE_WINDOW:
-        pError = (char *)"EGL_BAD_NATIVE_WINDOW";
+        pError = "EGL_BAD_NATIVE_WINDOW";
         break;
       case EGL_CONTEXT_LOST:
-        pError = (char *)"EGL_CONTEXT_LOST";
+        pError = "EGL_CONTEXT_LOST";
         break;
-      default:
-        ALOGE("eglError (0x%x) %s:%d\n", error, file, line);
-        return;
     }
     ALOGE("eglError (%s) %s:%d\n", pError, file, line);
-    return;
   }
-  return;
 }


### PR DESCRIPTION
`glGetError()` may return more than one error, yet these loops never
iterated more than once. This CL fixes that, and cleans up some useless
casting.

Same fix as Ib2d3a6a95726fa954426a3644635dcf41fb571db.

Bug: 150166387
Test: TreeHugger
Change-Id: I67f0f30445cfb6ce86c3de9984b4f87f9f302c1d
Signed-off-by: GhostMaster69-dev <rathore6375@gmail.com>